### PR TITLE
使用环境变量替换硬编码API地址

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,3 @@
+#API 基础地址
+#复制此文件为.env.example
+VITE_API_URL=http://localhost:8000/api

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,3 +1,3 @@
 #API 基础地址
-#复制此文件为.env.example
+#复制此文件为.env.development
 VITE_API_URL=http://localhost:8000/api

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+.env.development
+

--- a/frontend/src/pages/AIAssistant.tsx
+++ b/frontend/src/pages/AIAssistant.tsx
@@ -33,6 +33,8 @@ import { checkAndNotifyAchievements } from '../utils/achievementNotifier';
 import { useAuthStore } from '../store/authStore';
 const { Title, Paragraph, Text } = Typography;
 
+const API_BASE_URL = import.meta.env.VITE_API_URL;
+
 // 改造方案类型定义
 interface RedesignStep {
   title: string;
@@ -95,7 +97,7 @@ const AIAssistant: React.FC = () => {
       
       // 调用后端图片分析API
       const token = localStorage.getItem('auth_token');
-      const response = await fetch('http://localhost:8000/api/redesign/analyze/image', {
+      const response = await fetch(`${API_BASE_URL}/redesign/analyze/image`, {
         method: 'POST',
         headers: {
           'Authorization': `Bearer ${token}`,
@@ -144,7 +146,7 @@ const AIAssistant: React.FC = () => {
       
       // 调用后端改造方案生成API
       const token = localStorage.getItem('auth_token');
-      const response = await fetch('http://localhost:8000/api/redesign/generate', {
+      const response = await fetch(`${API_BASE_URL}/redesign/generate`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -169,8 +171,8 @@ const AIAssistant: React.FC = () => {
         total_cost: result.total_cost_estimate || '待评估',
         sustainability_score: result.sustainability_score || 7,
         tips: result.tips || [],
-        final_image: result.final_image_url ? `http://localhost:8000${result.final_image_url}` : undefined,
-        step_images: result.step_images ? result.step_images.map((url: string) => `http://localhost:8000${url}`) : []
+        final_image: result.final_image_url ? `${API_BASE_URL.replace('/api', '')}${result.final_image_url}` : undefined,
+step_images: result.step_images ? result.step_images.map((url: string) => `${API_BASE_URL.replace('/api', '')}${url}`) : []
       };
       
       setRedesignPlan(mappedResult);

--- a/frontend/src/pages/Community.tsx
+++ b/frontend/src/pages/Community.tsx
@@ -20,7 +20,8 @@ import { useAuthStore } from '../store/authStore';
 import { checkAndNotifyAchievements } from '../utils/achievementNotifier';
 const { Title, Paragraph } = Typography;
 const { TabPane } = Tabs;
-const API_BASE_URL = 'http://localhost:8000';
+// const API_BASE_URL = 'http://localhost:8000';
+const API_BASE_URL = import.meta.env.VITE_API_URL;
 const { TextArea } = Input;
 const { confirm } = Modal;
 
@@ -100,7 +101,7 @@ const Community: React.FC = () => {
   setLoading(true);
 
   try {
-    const url = `${API_BASE_URL}/api/community/posts?category=${category}&page=${page}&size=${size}`;
+    const url = `${API_BASE_URL}/community/posts?category=${category}&page=${page}&size=${size}`;
     const res = await fetch(url);
     const data = await res.json();
 
@@ -110,14 +111,14 @@ const Community: React.FC = () => {
         try {
           // 获取评论总数（只取第一页一条即可获取 total）
           const commentRes = await fetch(
-            `${API_BASE_URL}/api/community/posts/${post.id}/comments?page=1&size=1`
+            `${API_BASE_URL}/community/posts/${post.id}/comments?page=1&size=1`
           );
           const commentData = await commentRes.json();
 
           // 获取点赞状态
           const token = localStorage.getItem('auth_token');
           const likeStatusRes = await fetch(
-            `${API_BASE_URL}/api/community/posts/${post.id}/like/status`,
+            `${API_BASE_URL}/community/posts/${post.id}/like/status`,
             {
               headers: token ? { 'Authorization': `Bearer ${token}` } : {}
             }
@@ -163,7 +164,7 @@ const handleCreatePost = async (values: CreatePostFormValues) => {
     const token = localStorage.getItem('auth_token');
 
     // 1. 创建帖子
-    const postResponse = await fetch(`${API_BASE_URL}/api/community/posts`, {
+    const postResponse = await fetch(`${API_BASE_URL}/community/posts`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -192,7 +193,7 @@ const handleCreatePost = async (values: CreatePostFormValues) => {
         formData.append('file', file);
 
         const uploadResponse = await fetch(
-          `${API_BASE_URL}/api/community/posts/${postId}/images`,
+          `${API_BASE_URL}/community/posts/${postId}/images`,
           {
             method: 'POST',
             headers: { 'Authorization': `Bearer ${token}` },
@@ -229,7 +230,7 @@ const handleCreatePost = async (values: CreatePostFormValues) => {
 };
 
 const handlePreview = (imgUrl: string, title: string) => {
-  setPreviewImage(`${API_BASE_URL}/${imgUrl}`);
+  setPreviewImage(`${API_BASE_URL.replace('/api', '')}/${imgUrl}`);
   setPreviewTitle(title);
   setPreviewVisible(true);
 };
@@ -261,7 +262,7 @@ const handleDeletePostImageInEdit = async (
 
         // 调用删除图片接口
         const response = await fetch(
-          `${API_BASE_URL}/api/community/posts/${postId}/images/${imageId}`,
+          `${API_BASE_URL}/community/posts/${postId}/images/${imageId}`,
           {
             method: 'DELETE',
             headers: { 'Authorization': `Bearer ${token}` }
@@ -312,7 +313,7 @@ const fetchPostDetail = async (postId: number) => {
     ? { Authorization: `Bearer ${token}` }
     : {};
     // 1. 请求帖子详情
-    const response = await fetch(`${API_BASE_URL}/api/community/posts/${postId}`, { headers });
+    const response = await fetch(`${API_BASE_URL}/community/posts/${postId}`, { headers });
     const data = await response.json();
 
     // 2. 处理返回数据，保证 images 数组存在
@@ -380,7 +381,7 @@ const handleUpdatePost = async (values: CreatePostFormValues) => {
     }
 
     // 2. 更新帖子文本内容
-    const updateResponse = await fetch(`${API_BASE_URL}/api/community/posts/${editingPost.id}`, {
+    const updateResponse = await fetch(`${API_BASE_URL}/community/posts/${editingPost.id}`, {
       method: 'PUT',
       headers: {
         'Content-Type': 'application/json',
@@ -401,7 +402,7 @@ const handleUpdatePost = async (values: CreatePostFormValues) => {
           const formData = new FormData();
           formData.append('file', file);
 
-          return fetch(`${API_BASE_URL}/api/community/posts/${editingPost.id}/images`, {
+          return fetch(`${API_BASE_URL}/community/posts/${editingPost.id}/images`, {
             method: 'POST',
             headers: { 'Authorization': `Bearer ${token}` },
             body: formData
@@ -469,7 +470,7 @@ const deletePost = async (postId: number) => {
     }
 
     //调用删除接口
-    const response = await fetch(`${API_BASE_URL}/api/community/posts/${postId}`, {
+    const response = await fetch(`${API_BASE_URL}/community/posts/${postId}`, {
       method: 'DELETE',
       headers: {
         'Authorization': `Bearer ${token}` // 添加认证头
@@ -506,7 +507,7 @@ const fetchComments = async (postId: number, page: number = 1) => {
   try {
     // 1) 请求评论分页数据
     const response = await fetch(
-      `${API_BASE_URL}/api/community/posts/${postId}/comments?page=${page}&size=10`
+      `${API_BASE_URL}/community/posts/${postId}/comments?page=${page}&size=10`
     );
     const data = await response.json();
 
@@ -531,7 +532,7 @@ const fetchComments = async (postId: number, page: number = 1) => {
 
     try {
       const batchStatusResponse = await fetch(
-        `${API_BASE_URL}/api/community/comments/like/status/batch?comment_ids=${commentIds}`,
+        `${API_BASE_URL}/community/comments/like/status/batch?comment_ids=${commentIds}`,
         {
           headers: token ? { 'Authorization': `Bearer ${token}` } : {}
         }
@@ -585,7 +586,7 @@ const loadMoreComments = async () => {
 
   try {
     const res = await fetch(
-      `${API_BASE_URL}/api/community/posts/${currentPostId}/comments?page=${nextPage}&size=10`
+      `${API_BASE_URL}/community/posts/${currentPostId}/comments?page=${nextPage}&size=10`
     );
     const data = await res.json();
 
@@ -620,7 +621,7 @@ const handleSubmitComment = async () => {
     }
 
     // 创建评论
-    const commentRes = await fetch(`${API_BASE_URL}/api/community/posts/${currentPostId}/comments`, {
+    const commentRes = await fetch(`${API_BASE_URL}/community/posts/${currentPostId}/comments`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -645,7 +646,7 @@ const handleSubmitComment = async () => {
         formData.append('file', imageFile);
 
         const uploadRes = await fetch(
-          `${API_BASE_URL}/api/community/comments/${newComment.id}/images`,
+          `${API_BASE_URL}/community/comments/${newComment.id}/images`,
           {
             method: 'POST',
             headers: { 'Authorization': `Bearer ${token}` },
@@ -693,7 +694,7 @@ const deleteComment = async (commentId: number) => {
     }
 
     // 调用删除评论接口
-    const response = await fetch(`${API_BASE_URL}/api/community/comments/${commentId}`, {
+    const response = await fetch(`${API_BASE_URL}/community/comments/${commentId}`, {
       method: 'DELETE',
       headers: { 'Authorization': `Bearer ${token}` },
     });
@@ -739,7 +740,7 @@ const handleLike = async (postId: number) => {
       return;
     }
 
-    const response = await fetch(`${API_BASE_URL}/api/community/posts/${postId}/like`, {
+    const response = await fetch(`${API_BASE_URL}/community/posts/${postId}/like`, {
       method,
       headers: { 'Authorization': `Bearer ${token}` },
     });
@@ -790,7 +791,7 @@ const handleLikeComment = async (commentId: number) => {
       return;
     }
 
-    const response = await fetch(`${API_BASE_URL}/api/community/comments/${commentId}/like`, {
+    const response = await fetch(`${API_BASE_URL}/community/comments/${commentId}/like`, {
       method,
       headers: { 'Authorization': `Bearer ${token}` },
     });
@@ -985,7 +986,7 @@ const handleShare = (postId: number) => console.log('分享帖子:', postId);
                     {editingPost.images_with_id.map((img, index) => (
                         <Col key={img.id} xs={8} style={{position: 'relative'}}>
                           <img
-                              src={`${API_BASE_URL}/${img.file_path}`}
+                              src={`${API_BASE_URL.replace('/api', '')}/${img.file_path}`}
                               alt={`现有图片 ${index + 1}`}
                               style={{
                                 width: '100%',
@@ -1367,7 +1368,7 @@ const handleShare = (postId: number) => console.log('分享帖子:', postId);
                                 {post.images?.map((imgUrl, index) => (
                                     <Col key={index} xs={8}>
                                       <img
-                                          src={`${API_BASE_URL}/${imgUrl}`}
+                                          src={`${API_BASE_URL.replace('/api', '')}/${imgUrl}`}
                                           alt={`帖子图片 ${index + 1}`}
                                           style={{
                                             width: '100%',
@@ -1378,7 +1379,7 @@ const handleShare = (postId: number) => console.log('分享帖子:', postId);
                                           }}
                                           // 修复这里：使用新的预览方式
                                           onClick={() => {
-                                            setPreviewImage(`${API_BASE_URL}/${imgUrl}`);
+                                            setPreviewImage(`${API_BASE_URL.replace('/api', '')}/${imgUrl}`);
                                             setPreviewVisible(true);
                                           }}
                                       />

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -33,6 +33,8 @@ import { useAuthStore } from '../store/authStore';
 import { useNavigate } from 'react-router-dom';
 import {checkAndNotifyAchievements} from "../utils/achievementNotifier";
 
+const API_BASE_URL = import.meta.env.VITE_API_URL;
+
 const { Title, Paragraph } = Typography;
 interface Achievement {
   id: number;
@@ -168,7 +170,7 @@ const Profile: React.FC = () => {
         return;
       }
       
-      const response = await fetch('http://localhost:8000/api/auth/me', {
+      const response = await fetch(`${API_BASE_URL}/auth/me`, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
@@ -214,7 +216,7 @@ const getAchievementIcon = (name: string) => {
   setAchievementsLoading(true);
   try {
     // 先自动检查并发放成就
-    const checkResponse = await fetch(`http://localhost:8000/api/gamification/achievements/check/${userId}`, {
+    const checkResponse = await fetch(`${API_BASE_URL}/gamification/achievements/check/${userId}`, {
       method: 'POST'
     });
     const checkResult = await checkResponse.json();
@@ -224,7 +226,7 @@ const getAchievementIcon = (name: string) => {
     }
 
     // 再获取最新的成就状态
-    const response = await fetch(`http://localhost:8000/api/gamification/achievements/user/${userId}`);
+    const response = await fetch(`${API_BASE_URL}/gamification/achievements/user/${userId}`);
     const result: UserAchievementResponse = await response.json();
 
     if (result.code === 200) {
@@ -266,7 +268,7 @@ const getAchievementIcon = (name: string) => {
 const fetchLeaderboard = async (limit: number = 10): Promise<void> => {
   setLeaderboardLoading(true);
   try {
-    const response = await fetch(`http://localhost:8000/api/gamification/leaderboard?limit=${limit}`);
+    const response = await fetch(`${API_BASE_URL}/gamification/leaderboard?limit=${limit}`);
     const result: LeaderboardResponse = await response.json();
 
     if (result.code === 200) {
@@ -287,7 +289,7 @@ const fetchUserRanking = async (userId: number): Promise<void> => {
   setRankingLoading(true);
   try {
     // 先获取排行榜数据来计算准确排名
-    const response = await fetch(`http://localhost:8000/api/gamification/leaderboard?limit=100`);
+    const response = await fetch(`${API_BASE_URL}/gamification/leaderboard?limit=100`);
     const result: LeaderboardResponse = await response.json();
 
     if (result.code === 200) {
@@ -311,7 +313,7 @@ const fetchUserRanking = async (userId: number): Promise<void> => {
         });
       } else {
         // 用户不在前100名，需要单独查询
-        const userResponse = await fetch(`http://localhost:8000/api/gamification/leaderboard/user/${userId}`);
+        const userResponse = await fetch(`${API_BASE_URL}/gamification/leaderboard/user/${userId}`);
         const userResult: UserRankingResponse = await userResponse.json();
 
         if (userResult.code === 200) {
@@ -397,7 +399,7 @@ const calculatePointsProgress = (points: number) => {
 const fetchUserStats = async (userId: number): Promise<void> => {
   setStatsLoading(true);
   try {
-    const response = await fetch(`http://localhost:8000/api/community/users/${userId}/stats`);
+    const response = await fetch(`${API_BASE_URL}/community/users/${userId}/stats`);
     const result: UserStatsResponse = await response.json();
 
     if (result.code === 200) {
@@ -416,7 +418,7 @@ const fetchUserStats = async (userId: number): Promise<void> => {
 const fetchUserPosts = async (userId: number): Promise<void> => {
   setPostsLoading(true);
   try {
-    const response = await fetch(`http://localhost:8000/api/community/users/${userId}/posts`);
+    const response = await fetch(`${API_BASE_URL}/community/users/${userId}/posts`);
     const result: PostsResponse = await response.json();
 
     if (result.items) {
@@ -439,7 +441,7 @@ const fetchUserPosts = async (userId: number): Promise<void> => {
 const fetchLikedPosts = async (userId: number): Promise<void> => {
   setLikedPostsLoading(true);
   try {
-    const response = await fetch(`http://localhost:8000/api/community/users/${userId}/liked-posts`);
+    const response = await fetch(`${API_BASE_URL}/community/users/${userId}/liked-posts`);
     const result: PostsResponse = await response.json();
 
     if (result.items) {
@@ -648,7 +650,7 @@ const fetchLikedPosts = async (userId: number): Promise<void> => {
                                             {post.images.slice(0, 3).map((image, index) => (
                                                 <img
                                                     key={index}
-                                                    src={image.startsWith('http') ? image : `http://localhost:8000/${image}`}
+                                                    src={image.startsWith('http') ? image : `${API_BASE_URL.replace('/api', '')}/${image}`}
                                                     alt={`帖子图片 ${index + 1}`}
                                                     style={{
                                                       width: '80px',
@@ -761,7 +763,7 @@ const fetchLikedPosts = async (userId: number): Promise<void> => {
                                             {post.images.slice(0, 3).map((image, index) => (
                                                 <img
                                                     key={index}
-                                                    src={image.startsWith('http') ? image : `http://localhost:8000/${image}`}
+                                                    src={image.startsWith('http') ? image : `${API_BASE_URL.replace('/api', '')}/${image}`}
                                                     alt={`帖子图片 ${index + 1}`}
                                                     style={{
                                                       width: '80px',

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -5,8 +5,8 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
 // API基础URL
-const API_BASE_URL = 'http://localhost:8000/api';
-
+// const API_BASE_URL = 'http://localhost:8000/api';
+const API_BASE_URL = import.meta.env.VITE_API_URL;
 // 类型定义
 interface User {
   id: number;

--- a/frontend/src/utils/achievementNotifier.tsx
+++ b/frontend/src/utils/achievementNotifier.tsx
@@ -1,6 +1,6 @@
 // utils/achievementNotifier.tsx
 import { notification, Modal } from 'antd';
-
+const API_BASE_URL = import.meta.env.VITE_API_URL;
 // 定义成就类型
 interface Achievement {
   id: number;
@@ -38,7 +38,7 @@ const getAchievementIcon = (name: string): string => {
 // 检查并通知成就
 export const checkAndNotifyAchievements = async (userId: number, onAchievementsUpdated?: () => void): Promise<void> => {
   try {
-    const response = await fetch(`http://localhost:8000/api/gamification/achievements/check/${userId}`, {
+    const response = await fetch(`${API_BASE_URL}/gamification/achievements/check/${userId}`, {
       method: 'POST',
     });
 


### PR DESCRIPTION
将前端所有硬编码的 `localhost:8000` API地址替换为环境变量 `VITE_API_URL`
统一处理图片URL路径，使用 `.replace('/api', '')` 确保正确显示
- `frontend/.gitignore` - 添加环境变量文件忽略规则
- `frontend/.env.example` - 新增环境变量配置模板
使用说明：
1. 复制 `frontend/.env.example` 为 `frontend/.env.development`
2. 根据需要修改API地址
3. 生产环境在部署平台配置 `VITE_API_URL` 环境变量